### PR TITLE
Return value from protect()

### DIFF
--- a/lib/src/mutex.dart
+++ b/lib/src/mutex.dart
@@ -60,12 +60,15 @@ class Mutex {
   /// before the lock is released. The lock is always released
   /// (even if the critical section throws an exception).
   ///
-  /// Returns a Future that completes after the lock is released.
-
-  Future<void> protect(Function criticalSection) async {
+  /// Returns a Future that completes with the value returned by [criticalSection]
+  /// after the lock is released. The type parameter [T] is the return type of the
+  /// critical section function.
+  /// Often this does not need to be given as it can be inferred from the critical
+  /// section's return type
+  Future<T> protect<T>(T criticalSection()) async {
     await acquire();
     try {
-      await criticalSection();
+      return await criticalSection();
     } finally {
       release();
     }

--- a/test/mutex_test.dart
+++ b/test/mutex_test.dart
@@ -195,12 +195,30 @@ void main() {
           expect(m.isLocked, isTrue);
           throw const FormatException('testing');
         });
+        // ignore: dead_code
         fail('exception in critical section was not propagated');
       } on FormatException {
         expect(m.isLocked, isFalse);
       }
 
       expect(m.isLocked, isFalse);
+    });
+
+    test('value returned from critical section', () async {
+      final m = Mutex();
+
+      // explicit return type int
+      final value = await m.protect<int>(() => 35);
+      expect(value, 35);
+
+      // explicit return type String
+      final word = await m.protect<String>(() => '42');
+      expect(word, '42');
+
+      // inferred return type String
+      final data = await m.protect(() => '42');
+      expect(data, isA<String>());
+      expect(data.length, 2);
     });
   });
 }


### PR DESCRIPTION
The Mutex.protect() method is modified to return a Future that completes with the value returned by the criticalSection function. This adds useful functionality for many use cases.
Also added analyzer exception for dead code in 'lock released on exception' test.

Test cases have been added, and all existing tests remain green.