### PR TITLE
Return value from protect() take 2

### DIFF
--- a/lib/src/mutex.dart
+++ b/lib/src/mutex.dart
@@ -65,7 +65,7 @@ class Mutex {
   /// critical section function.
   /// Often this does not need to be given as it can be inferred from the critical
   /// section's return type
-  Future<T> protect<T>(T criticalSection()) async {
+  Future<T> protect<T>(Future<T> criticalSection()) async {
     await acquire();
     try {
       return await criticalSection();

--- a/test/mutex_test.dart
+++ b/test/mutex_test.dart
@@ -179,7 +179,7 @@ void main() {
     test('lock released on success', () async {
       final m = Mutex();
 
-      await m.protect(() {
+      await m.protect<void>(() async {
         // critical section
         expect(m.isLocked, isTrue);
       });
@@ -190,7 +190,7 @@ void main() {
       final m = Mutex();
 
       try {
-        await m.protect(() {
+        await m.protect(() async {
           // critical section
           expect(m.isLocked, isTrue);
           throw const FormatException('testing');
@@ -208,17 +208,38 @@ void main() {
       final m = Mutex();
 
       // explicit return type int
-      final value = await m.protect<int>(() => 35);
+      final value = await m.protect<int>(() async => 35);
       expect(value, 35);
+      expect(m.isLocked, isFalse);
 
       // explicit return type String
-      final word = await m.protect<String>(() => '42');
+      final word = await m.protect<String>(() async => '42');
       expect(word, '42');
+      expect(word.length, 2);
+      expect(m.isLocked, isFalse);
 
       // inferred return type String
-      final data = await m.protect(() => '42');
+      final data = await m.protect(() async => '42');
       expect(data, isA<String>());
       expect(data.length, 2);
+      expect(m.isLocked, isFalse);
+    });
+
+    test('nullable return value from critical section', () async {
+      final m = Mutex();
+      // explicit return type nullable String
+      final word = await m.protect<String?>(() async => null);
+      expect(word, null);
+    });
+
+    test('future returned from critical section', () async {
+      final m = Mutex();
+
+      // explicit return type void
+      final value = m.protect<void>(() async {});
+      expect(value, completes);
+      await value;
+      expect(m.isLocked, isFalse);
     });
   });
 }


### PR DESCRIPTION
As an extension for PR #7 I changed declaration of critical section to return Future<T> to reflect the fact that critical section should generally be asynchronous code.

Test cases have been updated and extended to ensure all types including void and nullable type can be returned.

Preexisting test cases use async critical sections